### PR TITLE
fix to text not appearing in light mode when generated

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -252,10 +252,10 @@ function getSpoonApi() {
         selectedImg.src = ApiData[recipeNum].image;
 
         //Changes amount of servings
-        selectedServings.innerHTML = ApiData[recipeNum].servings;
+        selectedServings.innerHTML = "Servings: " + ApiData[recipeNum].servings;
 
-        //Changes prep time
-        selectedPrepTime.innerHTML = ApiData[recipeNum].readyInMinutes + " minutes";
+        //Changes cook time
+        selectedPrepTime.innerHTML = "Cook Time: " + ApiData[recipeNum].readyInMinutes + " minutes";
 
         //Changes ingredients
         selectedIngredientList.replaceChildren();

--- a/index.html
+++ b/index.html
@@ -269,8 +269,8 @@
 										class="selected-food-img"
 									/>
 									<h5 class="selected-food-title">Beef Noodles</h5>
-									<p>Cook time: <span id="selected-food-prep-time"></span></p>
-									<p>Servings: <span id="selected-food-servings"></span></p>
+									<p><span id="selected-food-prep-time"></span></p>
+									<p><span id="selected-food-servings"></span></p>
 									<div class="sects">
 										<span>Ingredients</span>
 										<nl class="ingr"> </nl>


### PR DESCRIPTION
The text in light mode for servings and cook time when generated has been fixed from not being viewed. 